### PR TITLE
Adds ADFS Cookie support for on-premise ADFS - Closes #4

### DIFF
--- a/src/auth/IAuthOptions.ts
+++ b/src/auth/IAuthOptions.ts
@@ -28,6 +28,7 @@ export interface IOnpremiseUserCredentials extends IUserCredentials {
 
 export interface IAdfsUserCredentials extends IUserCredentials {
   domain?: string;
+  adfsCookie?: string;
   adfsUrl: string;
   relyingParty: string;
 }

--- a/src/auth/resolvers/AdfsCredentials.ts
+++ b/src/auth/resolvers/AdfsCredentials.ts
@@ -49,10 +49,11 @@ export class AdfsCredentials implements IAuthResolver {
         return this.postTokenData(data);
       })
       .then(data => {
+        let adfsCookie: string = (this._authOptions.adfsCookie !== undefined) ? this._authOptions.adfsCookie : consts.FedAuth;
         let notAfter: number = new Date(data[0]).getTime();
         let expiresIn: number = parseInt(((notAfter - new Date().getTime()) / 1000).toString(), 10);
         let response: IncomingMessage = data[1];
-        let authCookie: string = 'FedAuth=' + cookie.parse(response.headers['set-cookie'][0])[consts.FedAuth];
+        let authCookie: string = adfsCookie + '=' + cookie.parse(response.headers['set-cookie'][0])[adfsCookie];
 
         AdfsCredentials.CookieCache.set(cacheKey, authCookie, expiresIn);
 


### PR DESCRIPTION
@s-KaiNet 
 
This adds support for setting a custom ADFS 'FedAuth' cookie name that is required in some on-premise SharePoint environments using ADFS.

Closes #4 