### PR TITLE
FBA On-Premises auth mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Authentication options:
  * SharePoint 2013, 2016:
    * Addin only permissions
    * User credentials through the http ntlm handshake
+   * FBA based authentication
  * SharePoint Online:
    * Addin only permissions
    * SAML based with user credentials
@@ -66,13 +67,16 @@ Possible values for `credentialOptions` (depending on authentication strategy):
     - [Addin only permissions:](https://github.com/s-KaiNet/node-sp-auth/wiki/SharePoint%20on-premise%20addin%20only%20authentication)  
       `clientId`, `issuerId`, `realm`, `rsaPrivateKeyPath`, `shaThumbprint`
     - [User credentials through the http ntlm handshake:](https://github.com/s-KaiNet/node-sp-auth/wiki/SharePoint%20on-premise%20user%20credentials%20authentication)  
-      `username`, `password`, `domain`, `workstation`  
+      `username`, `password`, `domain`, `workstation`
+    - [User credentials for for based authentication (FBA):](https://github.com/s-KaiNet/node-sp-auth/wiki/SharePoint%20on-premise%20user%20credentials%20authentication)  
+      `username`, `password`, `fba` = true
 
  - SharePoint Online: 
    - [Addin only permissions:](https://github.com/s-KaiNet/node-sp-auth/wiki/SharePoint%20Online%20addin%20only%20authentication)  
      `clientId`, `clientSecret`
    - [SAML based with user credentials](https://github.com/s-KaiNet/node-sp-auth/wiki/SharePoint%20Online%20user%20credentials%20authentication)  
      `username` , `password`
+
  - [ADFS user credentials:](https://github.com/s-KaiNet/node-sp-auth/wiki/ADFS%20user%20credentials%20authentication)  
    `username`, `password`, `relyingParty`, `adfsUrl`, `adfsCookie`
 

--- a/src/Consts.ts
+++ b/src/Consts.ts
@@ -1,6 +1,7 @@
 export const SharePointServicePrincipal: string = '00000003-0000-0ff1-ce00-000000000000';
 export const HighTrustTokenLifeTime: number = 12 * 60 * 60;
 export const MSOnlineSts: string = 'https://login.microsoftonline.com/extSTS.srf';
+export const FbaAuthEndpoint: string = '_vti_bin/authentication.asmx';
 export const FormsPath: string = '_forms/default.aspx?wa=wsignin1.0';
 export const RtFa: string = 'rtFa';
 export const FedAuth: string = 'FedAuth';

--- a/src/auth/AuthResolverFactory.ts
+++ b/src/auth/AuthResolverFactory.ts
@@ -1,6 +1,7 @@
 import { IAuthOptions } from './IAuthOptions';
 
 import { IAuthResolver } from './IAuthResolver';
+import { OnpremiseFbaCredentials } from './resolvers/OnpremiseFbaCredentials';
 import { OnpremiseUserCredentials } from './resolvers/OnpremiseUserCredentials';
 import { OnlineUserCredentials } from './resolvers/OnlineUserCredentials';
 import { OnlineAddinOnly } from './resolvers/OnlineAddinOnly';
@@ -10,6 +11,10 @@ import * as authOptions from './IAuthOptions';
 
 export class AuthResolverFactory {
   public static resolve(siteUrl: string, options: IAuthOptions): IAuthResolver {
+
+    if (authOptions.isFbaCredentialsOnpremise(siteUrl, options)) {
+      return new OnpremiseFbaCredentials(siteUrl, options);
+    }
 
     if (authOptions.isUserCredentialsOnpremise(siteUrl, options)) {
       return new OnpremiseUserCredentials(siteUrl, options);

--- a/src/auth/IAuthOptions.ts
+++ b/src/auth/IAuthOptions.ts
@@ -75,7 +75,11 @@ export function isFbaCredentialsOnpremise(siteUrl: string, T: IAuthOptions): T i
   let isOnPrem: boolean = host.indexOf('.sharepoint.com') === -1 && host.indexOf('.sharepoint.cn') === -1;
 
   if (isOnPrem && (<IUserCredentials>T).username !== undefined && !isAdfsCredentials(T)) {
-    if (((<IOnpremiseUserCredentials>T).domain || '').length === 0 && ((<IOnpremiseUserCredentials>T).workstation || '').length === 0) {
+    if (
+      ((<IOnpremiseUserCredentials>T).domain || '').length === 0 
+      && ((<IOnpremiseUserCredentials>T).workstation || '').length === 0 
+      && (<IOnpremiseUserCredentials>T).username.indexOf('@') === -1
+    ) {
       return true;
     }
   }

--- a/src/auth/IAuthOptions.ts
+++ b/src/auth/IAuthOptions.ts
@@ -70,6 +70,19 @@ export function isUserCredentialsOnpremise(siteUrl: string, T: IAuthOptions): T 
   return false;
 }
 
+export function isFbaCredentialsOnpremise(siteUrl: string, T: IAuthOptions): T is IOnpremiseUserCredentials {
+  let host: string = (url.parse(siteUrl)).host;
+  let isOnPrem: boolean = host.indexOf('.sharepoint.com') === -1 && host.indexOf('.sharepoint.cn') === -1;
+
+  if (isOnPrem && (<IUserCredentials>T).username !== undefined && !isAdfsCredentials(T)) {
+    if (((<IOnpremiseUserCredentials>T).domain || '').length === 0 && ((<IOnpremiseUserCredentials>T).workstation || '').length === 0) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 export function isAdfsCredentials(T: IAuthOptions): T is IAdfsUserCredentials {
   return (<IAdfsUserCredentials>T).adfsUrl !== undefined;
 }

--- a/src/auth/IAuthOptions.ts
+++ b/src/auth/IAuthOptions.ts
@@ -21,6 +21,10 @@ export interface IUserCredentials {
   password: string;
 }
 
+export interface IOnpremiseFbaCredentials extends IUserCredentials {
+  fba: boolean;
+}
+
 export interface IOnpremiseUserCredentials extends IUserCredentials {
   domain?: string;
   workstation?: string;
@@ -70,19 +74,24 @@ export function isUserCredentialsOnpremise(siteUrl: string, T: IAuthOptions): T 
   return false;
 }
 
-export function isFbaCredentialsOnpremise(siteUrl: string, T: IAuthOptions): T is IOnpremiseUserCredentials {
+export function isFbaCredentialsOnpremise(siteUrl: string, T: IAuthOptions): T is IOnpremiseFbaCredentials {
   let host: string = (url.parse(siteUrl)).host;
   let isOnPrem: boolean = host.indexOf('.sharepoint.com') === -1 && host.indexOf('.sharepoint.cn') === -1;
 
-  if (isOnPrem && (<IUserCredentials>T).username !== undefined && !isAdfsCredentials(T)) {
-    if (
-      ((<IOnpremiseUserCredentials>T).domain || '').length === 0 
-      && ((<IOnpremiseUserCredentials>T).workstation || '').length === 0 
-      && (<IOnpremiseUserCredentials>T).username.indexOf('@') === -1
-    ) {
-      return true;
-    }
+  if (isOnPrem && (<IOnpremiseFbaCredentials>T).username !== undefined && (<IOnpremiseFbaCredentials>T).fba) {
+    return true;
   }
+
+  /* Automatic detection then only username and password provided */
+  // if (isOnPrem && (<IUserCredentials>T).username !== undefined && !isAdfsCredentials(T)) {
+  //   if (
+  //     ((<IOnpremiseUserCredentials>T).domain || '').length === 0
+  //     && ((<IOnpremiseUserCredentials>T).workstation || '').length === 0
+  //     && (<IOnpremiseUserCredentials>T).username.indexOf('@') === -1
+  //   ) {
+  //     return true;
+  //   }
+  // }
 
   return false;
 }

--- a/src/auth/resolvers/OnpremiseFbaCredentials.ts
+++ b/src/auth/resolvers/OnpremiseFbaCredentials.ts
@@ -74,7 +74,6 @@ export class OnpremiseFbaCredentials implements IAuthResolver {
         let cookieName: string = xmlDoc.childNamed('soap:Body').childNamed('LoginResponse').childNamed('LoginResult').childNamed('CookieName').val;
         let diffSeconds: number = parseInt(xmlDoc.childNamed('soap:Body').childNamed('LoginResponse').childNamed('LoginResult').childNamed('TimeoutSeconds').val);
         let cookieValue: string;
-        let cookieValueFull: string;
 
         if (errorCode === 'PasswordNotMatch') {
           throw new Error(`Password doesn't not match`);
@@ -86,7 +85,6 @@ export class OnpremiseFbaCredentials implements IAuthResolver {
         (response.headers['set-cookie'] || []).forEach((headerCookie: string) => {
           if (headerCookie.indexOf(consts.FedAuth) !== -1) {
             cookieValue = cookie.parse(headerCookie)[cookieName];
-            cookieValueFull = headerCookie;
           }
         });
 

--- a/src/auth/resolvers/OnpremiseFbaCredentials.ts
+++ b/src/auth/resolvers/OnpremiseFbaCredentials.ts
@@ -56,7 +56,7 @@ export class OnpremiseFbaCredentials implements IAuthResolver {
       json: false,
       simple: false,
       strictSSL: false,
-      transform: function(body, response, resolveWithFullResponse) {
+      transform: function(body: any, response: any, resolveWithFullResponse: any) {
         return response;
       }
     })
@@ -70,9 +70,14 @@ export class OnpremiseFbaCredentials implements IAuthResolver {
           throw new Error(`${errorCode}, ${errorMessage}`);
         }
 
-        let errorCode: string = xmlDoc.childNamed('soap:Body').childNamed('LoginResponse').childNamed('LoginResult').childNamed('ErrorCode').val;
-        let cookieName: string = xmlDoc.childNamed('soap:Body').childNamed('LoginResponse').childNamed('LoginResult').childNamed('CookieName').val;
-        let diffSeconds: number = parseInt(xmlDoc.childNamed('soap:Body').childNamed('LoginResponse').childNamed('LoginResult').childNamed('TimeoutSeconds').val);
+        let errorCode: string =
+          xmlDoc.childNamed('soap:Body').childNamed('LoginResponse').childNamed('LoginResult').childNamed('ErrorCode').val;
+        let cookieName: string =
+          xmlDoc.childNamed('soap:Body').childNamed('LoginResponse').childNamed('LoginResult').childNamed('CookieName').val;
+        let diffSeconds: number = parseInt(
+          xmlDoc.childNamed('soap:Body').childNamed('LoginResponse').childNamed('LoginResult').childNamed('TimeoutSeconds').val,
+          null
+        );
         let cookieValue: string;
 
         if (errorCode === 'PasswordNotMatch') {
@@ -80,7 +85,7 @@ export class OnpremiseFbaCredentials implements IAuthResolver {
         }
         if (errorCode !== 'NoError') {
           throw new Error(errorCode);
-        };
+        }
 
         (response.headers['set-cookie'] || []).forEach((headerCookie: string) => {
           if (headerCookie.indexOf(cookieName) !== -1) {

--- a/src/auth/resolvers/OnpremiseFbaCredentials.ts
+++ b/src/auth/resolvers/OnpremiseFbaCredentials.ts
@@ -1,0 +1,107 @@
+import * as Promise from 'bluebird';
+import * as _ from 'lodash';
+import * as util from 'util';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as url from 'url';
+import * as request from 'request-promise';
+import * as cookie from 'cookie';
+
+let xmldoc: any = require('xmldoc');
+
+import { IAuthResolver } from './../IAuthResolver';
+import { IOnpremiseUserCredentials } from './../IAuthOptions';
+import { IAuthResponse } from './../IAuthResponse';
+import { Cache } from './../../utils/Cache';
+import * as consts from './../../Consts';
+
+export class OnpremiseFbaCredentials implements IAuthResolver {
+
+  private static CookieCache: Cache = new Cache();
+
+  constructor(private _siteUrl: string, private _authOptions: IOnpremiseUserCredentials) { }
+
+  public getAuth(): Promise<IAuthResponse> {
+
+    let parsedUrl: url.Url = url.parse(this._siteUrl);
+    let host: string = parsedUrl.host;
+    let cacheKey: string = util.format('%s@%s', host, this._authOptions.username);
+    let cachedCookie: string = OnpremiseFbaCredentials.CookieCache.get<string>(cacheKey);
+
+    if (cachedCookie) {
+      return Promise.resolve({
+        headers: {
+          'Cookie': cachedCookie
+        }
+      });
+    }
+
+    let soapBody: string = _.template(
+      fs.readFileSync(
+        path.join(__dirname, '..', '..', '..', '..', 'templates', 'fba_login_wsfed.tmpl')
+      ).toString()
+    )({
+      username: this._authOptions.username,
+      password: this._authOptions.password
+    });
+
+    return <Promise<IAuthResponse>>request(<any>{
+      url: this._siteUrl + '/' + consts.FbaAuthEndpoint,
+      method: 'POST',
+      headers: {
+        'Content-Type': 'text/xml; charset=utf-8',
+        'Content-Length': soapBody.length
+      },
+      body: soapBody,
+      json: false,
+      simple: false,
+      strictSSL: false,
+      transform: function(body, response, resolveWithFullResponse) {
+        return response;
+      }
+    })
+      .then((response: any) => {
+
+        let xmlDoc: any = new xmldoc.XmlDocument(response.body);
+
+        if (xmlDoc.name === 'm:error') {
+          let errorCode: string = xmlDoc.childNamed('m:code').val;
+          let errorMessage: string = xmlDoc.childNamed('m:message').val;
+          throw new Error(`${errorCode}, ${errorMessage}`);
+        }
+
+        let errorCode: string = xmlDoc.childNamed('soap:Body').childNamed('LoginResponse').childNamed('LoginResult').childNamed('ErrorCode').val;
+        let cookieName: string = xmlDoc.childNamed('soap:Body').childNamed('LoginResponse').childNamed('LoginResult').childNamed('CookieName').val;
+        let diffSeconds: number = xmlDoc.childNamed('soap:Body').childNamed('LoginResponse').childNamed('LoginResult').childNamed('TimeoutSeconds').val;
+        let cookieValue: string;
+        let cookieValueFull: string;
+
+        if (errorCode === 'PasswordNotMatch') {
+          throw new Error(`Password doesn't not match`);
+        }
+        if (errorCode !== 'NoError') {
+          throw new Error(errorCode);
+        };
+
+        (response.headers['set-cookie'] || []).forEach((headerCookie: string) => {
+          if (headerCookie.indexOf(consts.FedAuth) !== -1) {
+            cookieValue = cookie.parse(headerCookie)[cookieName];
+            cookieValueFull = headerCookie;
+          }
+        });
+
+        let authCookie: string = `${cookieName}=${cookieValue}`;
+
+        OnpremiseFbaCredentials.CookieCache.set(cacheKey, authCookie, diffSeconds);
+
+        return {
+          headers: {
+            'Cookie': authCookie,
+            'Authorization': authCookie
+          }
+        };
+
+      });
+  };
+
+}

--- a/src/auth/resolvers/OnpremiseFbaCredentials.ts
+++ b/src/auth/resolvers/OnpremiseFbaCredentials.ts
@@ -62,6 +62,8 @@ export class OnpremiseFbaCredentials implements IAuthResolver {
     })
       .then((response: any) => {
 
+        console.log(response.body);
+
         let xmlDoc: any = new xmldoc.XmlDocument(response.body);
 
         if (xmlDoc.name === 'm:error') {
@@ -83,7 +85,7 @@ export class OnpremiseFbaCredentials implements IAuthResolver {
         };
 
         (response.headers['set-cookie'] || []).forEach((headerCookie: string) => {
-          if (headerCookie.indexOf(consts.FedAuth) !== -1) {
+          if (headerCookie.indexOf(cookieName) !== -1) {
             cookieValue = cookie.parse(headerCookie)[cookieName];
           }
         });

--- a/src/auth/resolvers/OnpremiseFbaCredentials.ts
+++ b/src/auth/resolvers/OnpremiseFbaCredentials.ts
@@ -46,7 +46,7 @@ export class OnpremiseFbaCredentials implements IAuthResolver {
     });
 
     return <Promise<IAuthResponse>>request(<any>{
-      url: this._siteUrl + '/' + consts.FbaAuthEndpoint,
+      url: this._siteUrl.split('/_api')[0] + '/' + consts.FbaAuthEndpoint,
       method: 'POST',
       headers: {
         'Content-Type': 'text/xml; charset=utf-8',
@@ -72,7 +72,7 @@ export class OnpremiseFbaCredentials implements IAuthResolver {
 
         let errorCode: string = xmlDoc.childNamed('soap:Body').childNamed('LoginResponse').childNamed('LoginResult').childNamed('ErrorCode').val;
         let cookieName: string = xmlDoc.childNamed('soap:Body').childNamed('LoginResponse').childNamed('LoginResult').childNamed('CookieName').val;
-        let diffSeconds: number = xmlDoc.childNamed('soap:Body').childNamed('LoginResponse').childNamed('LoginResult').childNamed('TimeoutSeconds').val;
+        let diffSeconds: number = parseInt(xmlDoc.childNamed('soap:Body').childNamed('LoginResponse').childNamed('LoginResult').childNamed('TimeoutSeconds').val);
         let cookieValue: string;
         let cookieValueFull: string;
 

--- a/src/auth/resolvers/OnpremiseFbaCredentials.ts
+++ b/src/auth/resolvers/OnpremiseFbaCredentials.ts
@@ -96,8 +96,7 @@ export class OnpremiseFbaCredentials implements IAuthResolver {
 
         return {
           headers: {
-            'Cookie': authCookie,
-            'Authorization': authCookie
+            'Cookie': authCookie
           }
         };
 

--- a/src/auth/resolvers/OnpremiseFbaCredentials.ts
+++ b/src/auth/resolvers/OnpremiseFbaCredentials.ts
@@ -62,8 +62,6 @@ export class OnpremiseFbaCredentials implements IAuthResolver {
     })
       .then((response: any) => {
 
-        console.log(response.body);
-
         let xmlDoc: any = new xmldoc.XmlDocument(response.body);
 
         if (xmlDoc.name === 'm:error') {

--- a/templates/fba_login_wsfed.tmpl
+++ b/templates/fba_login_wsfed.tmpl
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Body>
+    <Login xmlns="http://schemas.microsoft.com/sharepoint/soap/">
+      <username><%= username %></username>
+      <password><%= password %></password>
+    </Login>
+  </soap:Body>
+</soap:Envelope>

--- a/test/integration/config.sample.ts
+++ b/test/integration/config.sample.ts
@@ -9,6 +9,7 @@ import {
 export var onlineUrl: string = '[sharepoint online url]';
 export var onpremAdfsEnabledUrl: string = '[sharepint on premise url with adfs configured]';
 export var onpremNtlmEnabledUrl: string = '[sharepint on premise url with ntlm]';
+export var onpremFbaEnabledUrl: string = '[sharepint on premise url with fba auth]';
 
 export var onlineCreds: IUserCredentials = {
   username: '[username]',
@@ -23,6 +24,11 @@ export var onlineWithAdfsCreds: IUserCredentials = {
 export var onpremCreds: IOnpremiseUserCredentials = {
   username: '[username]',
   domain: '[domain]',
+  password: '[password]'
+};
+
+export var onpremFbaCreds: IOnpremiseUserCredentials = {
+  username: '[username]',
   password: '[password]'
 };
 

--- a/test/integration/config.sample.ts
+++ b/test/integration/config.sample.ts
@@ -1,6 +1,7 @@
 import {
   IUserCredentials,
   IOnpremiseUserCredentials,
+  IOnpremiseFbaCredentials,
   IOnPremiseAddinCredentials,
   IOnlineAddinCredentials,
   IAdfsUserCredentials
@@ -27,9 +28,10 @@ export var onpremCreds: IOnpremiseUserCredentials = {
   password: '[password]'
 };
 
-export var onpremFbaCreds: IOnpremiseUserCredentials = {
+export var onpremFbaCreds: IOnpremiseFbaCredentials = {
   username: '[username]',
-  password: '[password]'
+  password: '[password]',
+  fba: true
 };
 
 export var onpremAddinOnly: IOnPremiseAddinCredentials = {

--- a/test/integration/integration.spec.ts
+++ b/test/integration/integration.spec.ts
@@ -24,6 +24,11 @@ let tests: ITestInfo[] = [
     url: config.onpremNtlmEnabledUrl
   },
   {
+    name: 'fba on-premise user credentials',
+    creds: config.onpremFbaCreds,
+    url: config.onpremFbaEnabledUrl
+  },
+  {
     name: 'adfs online user credentials',
     creds: config.onlineWithAdfsCreds,
     url: config.onlineUrl


### PR DESCRIPTION
Hi Sergei,

Today I faced a situation when I got to communicate with SharePoint instance located on a web application with FBA (Asp.Net Membership) auth and realized that there was no auth mechanism for such a case.

Likely I was managed to create one.

`isFbaCredentialsOnpremise` detects if it's On-Prem, not ADFS and there are no domain and workstation (just username and password props) properties provided.
Then a request to _vti_bin/authentication.asmx is initiated to get auth cookie. The Cookie is cached for a timeout equal timeout value received from services.

`OnpremiseFbaCredentials` was tested stand along to receive auth cookie from the server.
Also, is was tested in a combination with sp-request and simple REST requests like web info, etc.

Could you please take a look for a possibility to merge the changes with your branch?
P.S. I tried to keep your programming style and naming conventions.

Thanks in advanced!