### PR TITLE
Auth templates to JavaScript modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "homepage": "https://github.com/s-KaiNet/node-sp-auth",
   "scripts": {
     "build": "npm run tslint && tsc -p . && npm run copy",
-    "copy": "cpy templates/**/* lib/templates && cpy src/auth/resolvers/ondemand/electron/*.* lib/src/auth/resolvers/ondemand/electron",
+    "copy": "cpy src/auth/resolvers/ondemand/electron/*.* lib/src/auth/resolvers/ondemand/electron",
     "dev": "npm run copy && tsc -p . --watch",
     "tslint": "tslint --project tsconfig.json --type-check",
     "prepublish": "rimraf -- lib && npm run build",

--- a/src/auth/resolvers/AdfsCredentials.ts
+++ b/src/auth/resolvers/AdfsCredentials.ts
@@ -2,8 +2,6 @@ import * as Promise from 'bluebird';
 import * as request from 'request-promise';
 import * as url from 'url';
 import * as _ from 'lodash';
-import * as fs from 'fs';
-import * as path from 'path';
 import * as cookie from 'cookie';
 import { IncomingMessage } from 'http';
 import * as util from 'util';
@@ -16,6 +14,8 @@ import { Cache } from './../../utils/Cache';
 import * as consts from './../../Consts';
 import { AdfsHelper } from './../../utils/AdfsHelper';
 import { SamlAssertion } from './../../utils/SamlAssertion';
+
+import { template as adfsSamlTokenTemplate } from './../../templates/AdfsSamlToken';
 
 export class AdfsCredentials implements IAuthResolver {
 
@@ -80,9 +80,7 @@ export class AdfsCredentials implements IAuthResolver {
   }
 
   private postTokenData(samlAssertion: SamlAssertion): Promise<[string, any]> {
-    let tokenPostTemplate: Buffer = fs.readFileSync(path.join(__dirname, '..', '..', '..', 'templates', 'adfs_saml_token.tmpl'));
-
-    let result: string = _.template(tokenPostTemplate.toString())({
+    let result: string = _.template(adfsSamlTokenTemplate)({
       created: samlAssertion.notBefore,
       expires: samlAssertion.notAfter,
       relyingParty: this._authOptions.relyingParty,

--- a/src/auth/resolvers/OnlineUserCredentials.ts
+++ b/src/auth/resolvers/OnlineUserCredentials.ts
@@ -2,10 +2,8 @@ import * as Promise from 'bluebird';
 import * as url from 'url';
 import * as util from 'util';
 import * as _ from 'lodash';
-import * as fs from 'fs';
 import * as request from 'request-promise';
 import * as cookie from 'cookie';
-import * as path from 'path';
 import { IncomingMessage } from 'http';
 
 let xmldoc: any = require('xmldoc');
@@ -16,6 +14,9 @@ import { IAuthResponse } from './../IAuthResponse';
 import { Cache } from './../../utils/Cache';
 import * as consts from './../../Consts';
 import { AdfsHelper } from './../../utils/AdfsHelper';
+
+import { template as onlineSamlWsfedAdfsTemplate } from './../../templates/OnlineSamlWsfedAdfs';
+import { template as onlineSamlWsfedTemplate } from './../../templates/OnlineSamlWsfed';
 
 export class OnlineUserCredentials implements IAuthResolver {
 
@@ -124,11 +125,10 @@ export class OnlineUserCredentials implements IAuthResolver {
 
         let siteUrlParsed: url.Url = url.parse(this._siteUrl);
         let rootSiteUrl: string = siteUrlParsed.protocol + '//' + siteUrlParsed.host;
-        let tokenRequest: string = _.template(
-          fs.readFileSync(path.join(__dirname, '..', '..', '..', 'templates', 'online_saml_wsfed_adfs.tmpl')).toString())({
-            endpoint: rootSiteUrl,
-            token: samlAssertion.value
-          });
+        let tokenRequest: string = _.template(onlineSamlWsfedAdfsTemplate)({
+          endpoint: rootSiteUrl,
+          token: samlAssertion.value
+        });
 
         return request.post(consts.MSOnlineSts, {
           body: tokenRequest,
@@ -147,12 +147,11 @@ export class OnlineUserCredentials implements IAuthResolver {
     let host: string = parsedUrl.host;
     let spFormsEndPoint = `${parsedUrl.protocol}//${host}/${consts.FormsPath}`;
 
-    let samlBody: string = _.template(
-      fs.readFileSync(path.join(__dirname, '..', '..', '..', 'templates', 'online_saml_wsfed.tmpl')).toString())({
-        username: this._authOptions.username,
-        password: this._authOptions.password,
-        endpoint: spFormsEndPoint
-      });
+    let samlBody: string = _.template(onlineSamlWsfedTemplate)({
+      username: this._authOptions.username,
+      password: this._authOptions.password,
+      endpoint: spFormsEndPoint
+    });
 
     return request
       .post(consts.MSOnlineSts, {

--- a/src/auth/resolvers/OnpremiseFbaCredentials.ts
+++ b/src/auth/resolvers/OnpremiseFbaCredentials.ts
@@ -1,8 +1,6 @@
 import * as Promise from 'bluebird';
 import * as _ from 'lodash';
 import * as util from 'util';
-import * as fs from 'fs';
-import * as path from 'path';
 import * as url from 'url';
 import * as request from 'request-promise';
 import * as cookie from 'cookie';
@@ -14,6 +12,8 @@ import { IOnpremiseUserCredentials } from './../IAuthOptions';
 import { IAuthResponse } from './../IAuthResponse';
 import { Cache } from './../../utils/Cache';
 import * as consts from './../../Consts';
+
+import { template as fbaLoginWsfedTemplate } from './../../templates/FbaLoginWsfed';
 
 export class OnpremiseFbaCredentials implements IAuthResolver {
 
@@ -36,11 +36,7 @@ export class OnpremiseFbaCredentials implements IAuthResolver {
       });
     }
 
-    let soapBody: string = _.template(
-      fs.readFileSync(
-        path.join(__dirname, '..', '..', '..', 'templates', 'fba_login_wsfed.tmpl')
-      ).toString()
-    )({
+    let soapBody: string = _.template(fbaLoginWsfedTemplate)({
       username: this._authOptions.username,
       password: this._authOptions.password
     });

--- a/src/templates/AdfsSamlToken.ts
+++ b/src/templates/AdfsSamlToken.ts
@@ -1,0 +1,17 @@
+export const template = `
+  <t:RequestSecurityTokenResponse xmlns:t="http://schemas.xmlsoap.org/ws/2005/02/trust">
+    <t:Lifetime>
+      <wsu:Created xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd"><%= created %></wsu:Created>
+      <wsu:Expires xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd"><%= expires %></wsu:Expires>
+    </t:Lifetime>
+    <wsp:AppliesTo xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy">
+      <wsa:EndpointReference xmlns:wsa="http://www.w3.org/2005/08/addressing">
+        <wsa:Address><%= relyingParty %></wsa:Address>
+      </wsa:EndpointReference>
+    </wsp:AppliesTo>
+    <t:RequestedSecurityToken><%= token %></t:RequestedSecurityToken>
+    <t:TokenType>urn:oasis:names:tc:SAML:1.0:assertion</t:TokenType>
+    <t:RequestType>http://schemas.xmlsoap.org/ws/2005/02/trust/Issue</t:RequestType>
+    <t:KeyType>http://schemas.xmlsoap.org/ws/2005/05/identity/NoProofKey</t:KeyType>
+  </t:RequestSecurityTokenResponse>
+`;

--- a/src/templates/AdfsSamlWsfed.ts
+++ b/src/templates/AdfsSamlWsfed.ts
@@ -1,0 +1,28 @@
+export const template = `
+  <s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:a="http://www.w3.org/2005/08/addressing" xmlns:u="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">
+    <s:Header>
+      <a:Action s:mustUnderstand="1">http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue</a:Action>
+      <a:ReplyTo>
+        <a:Address>http://www.w3.org/2005/08/addressing/anonymous</a:Address>
+      </a:ReplyTo>
+      <a:To s:mustUnderstand="1"><%= to %></a:To>
+      <o:Security s:mustUnderstand="1" xmlns:o="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">
+        <o:UsernameToken u:Id="uuid-7b105801-44ac-4da7-aa69-a87f9db37299-1">
+          <o:Username><%= username %></o:Username>
+          <o:Password Type="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText"><%= password %></o:Password>
+        </o:UsernameToken>
+      </o:Security>
+    </s:Header>
+    <s:Body>
+      <trust:RequestSecurityToken xmlns:trust="http://docs.oasis-open.org/ws-sx/ws-trust/200512">
+        <wsp:AppliesTo xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy">
+          <wsa:EndpointReference xmlns:wsa="http://www.w3.org/2005/08/addressing">
+            <wsa:Address><%= relyingParty %></wsa:Address>
+          </wsa:EndpointReference>
+        </wsp:AppliesTo>
+        <trust:KeyType>http://docs.oasis-open.org/ws-sx/ws-trust/200512/Bearer</trust:KeyType>
+        <trust:RequestType>http://docs.oasis-open.org/ws-sx/ws-trust/200512/Issue</trust:RequestType>
+      </trust:RequestSecurityToken>
+    </s:Body>
+  </s:Envelope>
+`;

--- a/src/templates/FbaLoginWsfed.ts
+++ b/src/templates/FbaLoginWsfed.ts
@@ -1,0 +1,11 @@
+export const template = `
+  <?xml version="1.0" encoding="utf-8"?>
+  <soap:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+    <soap:Body>
+      <Login xmlns="http://schemas.microsoft.com/sharepoint/soap/">
+        <username><%= username %></username>
+        <password><%= password %></password>
+      </Login>
+    </soap:Body>
+  </soap:Envelope>
+`;

--- a/src/templates/OnlineSamlWsfed.ts
+++ b/src/templates/OnlineSamlWsfed.ts
@@ -1,0 +1,29 @@
+export const template = `
+  <s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:a="http://www.w3.org/2005/08/addressing" xmlns:u="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">
+    <s:Header>
+      <a:Action s:mustUnderstand="1">http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue</a:Action>
+      <a:ReplyTo>
+        <a:Address>http://www.w3.org/2005/08/addressing/anonymous</a:Address>
+      </a:ReplyTo>
+      <a:To s:mustUnderstand="1">https://login.microsoftonline.com/extSTS.srf</a:To>
+      <o:Security s:mustUnderstand="1" xmlns:o="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">
+        <o:UsernameToken>
+          <o:Username><%= username %></o:Username>
+          <o:Password><%= password %></o:Password>
+        </o:UsernameToken>
+      </o:Security>
+    </s:Header>
+    <s:Body>
+      <t:RequestSecurityToken xmlns:t="http://schemas.xmlsoap.org/ws/2005/02/trust">
+        <wsp:AppliesTo xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy">
+          <a:EndpointReference>
+            <a:Address><%= endpoint %></a:Address>
+          </a:EndpointReference>
+        </wsp:AppliesTo>
+        <t:KeyType>http://schemas.xmlsoap.org/ws/2005/05/identity/NoProofKey</t:KeyType>
+        <t:RequestType>http://schemas.xmlsoap.org/ws/2005/02/trust/Issue</t:RequestType>
+        <t:TokenType>urn:oasis:names:tc:SAML:1.0:assertion</t:TokenType>
+      </t:RequestSecurityToken>
+    </s:Body>
+  </s:Envelope>
+`;

--- a/src/templates/OnlineSamlWsfedAdfs.ts
+++ b/src/templates/OnlineSamlWsfedAdfs.ts
@@ -1,0 +1,24 @@
+export const template = `
+  <s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:a="http://www.w3.org/2005/08/addressing" xmlns:u="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">
+    <s:Header>
+      <a:Action s:mustUnderstand="1">http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue</a:Action>
+      <a:ReplyTo>
+        <a:Address>http://www.w3.org/2005/08/addressing/anonymous</a:Address>
+      </a:ReplyTo>
+      <a:To s:mustUnderstand="1">https://login.microsoftonline.com/extSTS.srf</a:To>
+      <o:Security s:mustUnderstand="1" xmlns:o="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"><%= token %></o:Security>
+    </s:Header>
+    <s:Body>
+      <t:RequestSecurityToken xmlns:t="http://schemas.xmlsoap.org/ws/2005/02/trust">
+        <wsp:AppliesTo xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy">
+          <a:EndpointReference>
+            <a:Address><%= endpoint %></a:Address>
+          </a:EndpointReference>
+        </wsp:AppliesTo>
+        <t:KeyType>http://schemas.xmlsoap.org/ws/2005/05/identity/NoProofKey</t:KeyType>
+        <t:RequestType>http://schemas.xmlsoap.org/ws/2005/02/trust/Issue</t:RequestType>
+        <t:TokenType>urn:oasis:names:tc:SAML:1.0:assertion</t:TokenType>
+      </t:RequestSecurityToken>
+    </s:Body>
+  </s:Envelope>
+`;

--- a/src/utils/AdfsHelper.ts
+++ b/src/utils/AdfsHelper.ts
@@ -2,20 +2,19 @@ import * as Promise from 'bluebird';
 import * as request from 'request-promise';
 import * as url from 'url';
 import * as _ from 'lodash';
-import * as fs from 'fs';
-import * as path from 'path';
 let xmldoc: any = require('xmldoc');
 
 import { IAdfsUserCredentials } from './../auth/IAuthOptions';
 import { SamlAssertion } from './SamlAssertion';
 
+import { template as adfsSamlWsfedTemplate } from './../templates/AdfsSamlWsfed';
+
 export class AdfsHelper {
   public static getSamlAssertion(siteUrl: string, credentials: IAdfsUserCredentials): Promise<SamlAssertion> {
     let adfsHost: string = url.parse(credentials.adfsUrl).host;
     let usernameMixedUrl = `https://${adfsHost}/adfs/services/trust/13/usernamemixed`;
-    let samlTemplate: Buffer = fs.readFileSync(path.join(__dirname, '..', '..', 'templates', 'adfs_saml_wsfed.tmpl'));
 
-    let samlBody: string = _.template(samlTemplate.toString())({
+    let samlBody: string = _.template(adfsSamlWsfedTemplate)({
       to: usernameMixedUrl,
       username: credentials.username,
       password: credentials.password,


### PR DESCRIPTION
Hi Sergei,

Could you please take a look at this PR.

The idea behind the changes is to allow bundling server-side jobs which are using node-sp-auth to a single script. Such bundling can affect positively on execution performance, e.g. for Azure Functions.

If to bundle current version it fails on the lines trying reading the `.tmpl` files:
```
fs.readFileSync(path.join(__dirname, '..', '..', '..', 'templates', '_path_to_tmpl_file_.tmpl')).toString())
```
Because being in a bundle the path to a `.tmpl` can't be resolved under some circumstancies. And these template files content can't be bundled as webpack can't process fs.readFileSync.

All the templates are just a text files with XMLs templates. I moved them to ES modules. After such a change bundling includes all templates.


Thanks!