### PR TITLE
OnDemand: optional TTL and electron script formatting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-sp-auth",
-  "version": "2.3.4",
+  "version": "2.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/auth/IAuthOptions.ts
+++ b/src/auth/IAuthOptions.ts
@@ -46,6 +46,7 @@ export interface IOnDemandCredentials {
   electron?: string;
   force?: boolean;
   persist?: boolean;
+  ttl?: number; // session TTL in minutes
 }
 
 export type IAuthOptions =

--- a/src/auth/resolvers/ondemand/electron/main.js
+++ b/src/auth/resolvers/ondemand/electron/main.js
@@ -1,25 +1,26 @@
-const electron = require('electron')
-var process = require('process');
+const electron = require('electron');
+const process = require('process');
 
 // Module to control application life.
-const app = electron.app
+const app = electron.app;
 app.commandLine.appendSwitch('ignore-certificate-errors');
 // Module to create native browser window.
-const BrowserWindow = electron.BrowserWindow
+const BrowserWindow = electron.BrowserWindow;
 
-const path = require('path')
-const url = require('url')
+const path = require('path');
+const url = require('url');
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
-let mainWindow;
+let mainWindow = null;
 
-function createWindow() {
+const createWindow = () => {
   let siteUrl = process.argv[2];
   let force = process.argv[3] === 'true';
   if (siteUrl.endsWith('/')) {
     siteUrl = siteUrl.slice(0, -1);
   }
+
   // Create the browser window.
   mainWindow = new BrowserWindow({
     width: 500,
@@ -34,57 +35,63 @@ function createWindow() {
   mainWindow.setMenu(null);
   // and load the index.html of the app.
   if (force) {
-    mainWindow.webContents.session.clearStorageData([], function () {
+    mainWindow.webContents.session.clearStorageData([], () => {
       mainWindow.loadURL(siteUrl);
     });
   } else {
     mainWindow.loadURL(siteUrl);
   }
 
-  mainWindow.webContents.on('dom-ready', function (data) {
-    let loadedUrl = mainWindow.webContents.getURL();
-
+  mainWindow.webContents.on('dom-ready', (data) => {
+    const loadedUrl = mainWindow.webContents.getURL();
     if (loadedUrl.indexOf(siteUrl) !== -1 && (loadedUrl.indexOf(siteUrl + '/_layouts/15/start.aspx') !== -1 || loadedUrl.indexOf(siteUrl + '/_') === -1)) {
-      let session = mainWindow.webContents.session;
-      let host = url.parse(siteUrl).hostname;
-      let isOnPrem = host.indexOf('.sharepoint.com') === -1 && host.indexOf('.sharepoint.cn') === -1;
+      const session = mainWindow.webContents.session;
+      const host = url.parse(siteUrl).hostname;
+      const isOnPrem = host.indexOf('.sharepoint.com') === -1
+        && host.indexOf('.sharepoint.cn') === -1
+        && host.indexOf('.sharepoint.de') === -1
+        && host.indexOf('.sharepoint-mil.us') === -1
+        && host.indexOf('.sharepoint.us') === -1;
       let domain;
-
       if (isOnPrem) {
         domain = host;
       } else if (host.indexOf('.sharepoint.com') !== -1) {
         domain = '.sharepoint.com';
       } else if (host.indexOf('.sharepoint.cn') !== -1) {
         domain = '.sharepoint.cn';
+      } else if (host.indexOf('.sharepoint.de') !== -1) {
+        domain = '.sharepoint.de';
+      } else if (host.indexOf('.sharepoint-mil.us') !== -1) {
+        domain = '.sharepoint-mil.us';
+      } else if (host.indexOf('.sharepoint.us') !== -1) {
+        domain = '.sharepoint.us';
       } else {
         throw new Error('Unable to resolve domain');
       }
-
       session.cookies.get({ domain: domain }, (error, cookies) => {
         if (error) {
           console.log(error);
           throw error;
         }
-
         console.log('#{');
-        cookies.forEach(function (cookie) {
+        cookies.forEach(cookie => {
           console.log(JSON.stringify(cookie));
           console.log(';#;');
         });
         console.log('}#');
         mainWindow.close();
-      })
+      });
     }
   });
 
   // Emitted when the window is closed.
-  mainWindow.on('closed', function () {
+  mainWindow.on('closed', () => {
     // Dereference the window object, usually you would store windows
     // in an array if your app supports multi windows, this is the time
     // when you should delete the corresponding element.
-    mainWindow = null
-  })
-}
+    mainWindow = null;
+  });
+};
 
 app.on('login', (event, webContents, request, authInfo, callback) => {
   event.preventDefault();
@@ -95,11 +102,9 @@ app.on('login', (event, webContents, request, authInfo, callback) => {
     height: 100,
     width: 500
   });
-
   child.setMenu(null);
   child.loadURL(`file://${__dirname}/no-ntlm.html`);
-
-  child.on('closed', function () {
+  child.on('closed', () => {
     mainWindow.close();
   });
 });
@@ -107,21 +112,21 @@ app.on('login', (event, webContents, request, authInfo, callback) => {
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
-app.on('ready', createWindow)
+app.on('ready', createWindow);
 
 // Quit when all windows are closed.
-app.on('window-all-closed', function () {
+app.on('window-all-closed', () => {
   // On OS X it is common for applications and their menu bar
   // to stay active until the user quits explicitly with Cmd + Q
   if (process.platform !== 'darwin') {
-    app.quit()
+    app.quit();
   }
-})
+});
 
-app.on('activate', function () {
+app.on('activate', () => {
   // On OS X it's common to re-create a window in the app when the
   // dock icon is clicked and there are no other windows open.
   if (mainWindow === null) {
-    createWindow()
+    createWindow();
   }
-})
+});

--- a/src/auth/resolvers/ondemand/electron/no-ntlm.html
+++ b/src/auth/resolvers/ondemand/electron/no-ntlm.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 <html>
-
 <head>
   <meta charset="UTF-8">
   <title>Error</title>
 </head>
-
 <body>
   <h3 style="color: red">Integrated windows authentication isn't supported</h3>
 </body>


### PR DESCRIPTION
PR introduces optional TTL setting for OnDemand auth strategy. Also, some minor style fixes have been applied to electron main.js.

## Premises

On one of the projects, we experience a tricky situation with On-Prem ADFS auth, there a service is probably misconfigured with a customer, auth fails with 307 temporary redirect status code, and we can't affect on the settings. On-Demand auth works like a charm and a real day saver.

Yet, there are some challenges with On-Demand, which we've faced. Timeout is extremely short, around 10-15 minutes or so. And it happens that node-sp-auth expect persisted cookie to be valid, while it's already expired. Requests ended up with 401/403 after a while and we got to delete a file with saved cookie manually each time to get a possibility to authenticate.

I've decided to apply an optional TTL in minutes to get a capability tweak it. It can be a better experience entering OnDemand creds into the popup and continue a process than, stopping a process, deleting persisted cookie file and restart.

Not a perfect I know. I'm thinking about some sort of refreshing by opening electron window for a moment and prolong the session or something, yet not found a solution.

@s-KaiNet, could you please take a look at apply changes? They are really minor right now but bring TTL configuration possibility.
