### PR TITLE
HostingEnvironment.Production as default for O365 Dedicated

### DIFF
--- a/src/utils/UrlHelper.ts
+++ b/src/utils/UrlHelper.ts
@@ -29,6 +29,7 @@ export class UrlHelper {
       return HostingEnvironment.USGovernment;
     }
 
-    throw new Error('Unable to resolve hosting environment. Site url: ' + siteUrl);
+    return HostingEnvironment.Production; // As default, for O365 Dedicated, #ToInvestigate
+    // throw new Error('Unable to resolve hosting environment. Site url: ' + siteUrl);
   }
 }


### PR DESCRIPTION
Closes #39, maybe it can be a temporary solution until any strict criteria for O365 Dedicated (on a custom domain) is introduced.
