### PR TITLE
ADFS auth & multiple cookies fix

### DIFF
--- a/src/auth/resolvers/AdfsCredentials.ts
+++ b/src/auth/resolvers/AdfsCredentials.ts
@@ -66,7 +66,11 @@ export class AdfsCredentials implements IAuthResolver {
         let notAfter: number = new Date(data[0]).getTime();
         let expiresIn: number = parseInt(((notAfter - new Date().getTime()) / 1000).toString(), 10);
         let response: IncomingMessage = data[1];
-        let authCookie: string = adfsCookie + '=' + cookie.parse(response.headers['set-cookie'][0])[adfsCookie];
+
+        let authCookie: string = adfsCookie + '=' +
+          response.headers['set-cookie']
+            .map((cookieString: string) => cookie.parse(cookieString)[adfsCookie])
+            .filter((cookieString: string) => typeof cookieString !== 'undefined')[0];
 
         AdfsCredentials.CookieCache.set(cacheKey, authCookie, expiresIn);
 


### PR DESCRIPTION
There are some situations when ADFS auth cookie is not on the first position (`response.headers['set-cookie'][0]`) as a result authentication might fail.

The PR amends this situation by iterating through response cookies and searching for a specific one then using it, no matter the position of the cookie.

Looking forward to merging the PR. Once again thank you so much for such a great library!