### PR TITLE
node-sp-auth-config dependency bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "jsonwebtoken": "8.5.1",
     "lodash.template": "4.5.0",
     "node-ntlm-client": "0.1.2",
-    "node-sp-auth-config": "2.9.4",
+    "node-sp-auth-config": "3.0.1",
     "xmldoc": "1.1.2"
   }
 }


### PR DESCRIPTION
@s-KaiNet,

node-sp-auth-config was aligned with v3 changes during the beta correspondingly.
Currently, as v2 is referenced it leads to v2 node-sp-auth & node-sp-auth-config also being installed into scoped module node_modules together with v3. 

Could you please bump node-sp-auth-config to recent?