### PR TITLE
Makes rejectUnauthorized configurable and default false

### DIFF
--- a/src/auth/IAuthOptions.ts
+++ b/src/auth/IAuthOptions.ts
@@ -33,6 +33,7 @@ export interface IOnpremiseFbaCredentials extends IUserCredentials {
 export interface IOnpremiseUserCredentials extends IUserCredentials {
   domain?: string;
   workstation?: string;
+  rejectUnauthorized?: boolean;
 }
 
 export interface IAdfsUserCredentials extends IUserCredentials {

--- a/src/auth/resolvers/OnpremiseTmgCredentials.ts
+++ b/src/auth/resolvers/OnpremiseTmgCredentials.ts
@@ -35,7 +35,7 @@ export class OnpremiseTmgCredentials implements IAuthResolver {
     const isHttps: boolean = url.parse(this._siteUrl).protocol === 'https:';
 
     const keepaliveAgent: any = isHttps ?
-      new https.Agent({ keepAlive: true, rejectUnauthorized: false }) :
+      new https.Agent({ keepAlive: true, rejectUnauthorized: !!this._authOptions.rejectUnauthorized }) :
       new http.Agent({ keepAlive: true });
 
     return request({

--- a/src/auth/resolvers/OnpremiseUserCredentials.ts
+++ b/src/auth/resolvers/OnpremiseUserCredentials.ts
@@ -34,7 +34,7 @@ export class OnpremiseUserCredentials implements IAuthResolver {
 
     const isHttps: boolean = url.parse(this._siteUrl).protocol === 'https:';
 
-    const keepaliveAgent: any = isHttps ? new https.Agent({ keepAlive: true, rejectUnauthorized: false }) :
+    const keepaliveAgent: any = isHttps ? new https.Agent({ keepAlive: true, rejectUnauthorized: !!ntlmOptions.rejectUnauthorized }) :
       new http.Agent({ keepAlive: true });
 
     return request({


### PR DESCRIPTION
This adds the auth options property `rejectUnauthorized`
to the IOnpremiseUserCredentials interface so that TLS
errors can be rejected during authentication.

The default is to reject invalid TLS connections.

This references #93.
