### PR TITLE
On-demand fix

### DIFF
--- a/src/auth/resolvers/OnDemand/OnDemand.ts
+++ b/src/auth/resolvers/OnDemand/OnDemand.ts
@@ -99,9 +99,16 @@ export class OnDemand implements IAuthResolver {
   private saveAuthData(dataPath: string): ICookie[] {
 
     const electronExecutable = this._authOptions.electron || 'electron';
-    const isWindows = (process.platform.lastIndexOf('win') === 0);
-    const options: any = isWindows ? { shell: true } : undefined;
-    const output = childProcess.execFileSync(electronExecutable, [path.join(__dirname, 'electron/main.js'), '--', this._siteUrl, this._authOptions.force.toString()], options).toString();
+    const electronProc = childProcess.spawnSync(
+      electronExecutable,
+      [
+        path.join(__dirname, 'electron/main.js'),
+        '--',
+        this._siteUrl,
+        this._authOptions.force === true ? 'true' : 'false'
+      ]
+    );
+    const output = electronProc.stdout.toString();
 
     const cookieRegex = /#\{([\s\S]+?)\}#/gm;
     const cookieData = cookieRegex.exec(output);

--- a/src/auth/resolvers/ondemand/electron/main.js
+++ b/src/auth/resolvers/ondemand/electron/main.js
@@ -4,6 +4,7 @@ const process = require('process');
 // Module to control application life.
 const app = electron.app;
 app.commandLine.appendSwitch('ignore-certificate-errors');
+app.commandLine.appendSwitch('no-sandbox');
 // Module to create native browser window.
 const BrowserWindow = electron.BrowserWindow;
 


### PR DESCRIPTION
When a node.js script uses `node-sp-auth` and uses on-demand authentication the `electron` dependency might not be installed globally, but may instead simply be in the project local dependencies or even as a `devDependency`. This means the electron package might easily be located in a path that contains spaces. (This would also be the case if the directory `npm` installs global packages to contains spaces, which is common on Windows systems where the user name contains spaces).

On Windows the current code uses `childProcess.executeFileSync` with the `shell: true` option. If electron is located in a path with spaces launching the electron process fails (since the path is not quoted).

To fix this, this PR uses `childProcess.spawnSync` instead. This function will automatically quote arguments as appropriate for the current OS. This will also address the possibility of having the `main.js` file in a path with spaces or spaces in the SharePoint Site URL.

Additionally I have run into situations where electron does not work on my machine, after debugging I found the electron error message

> GPU process launch failed: error_code=18

After some googling this seems to be related to https://github.com/electron/electron/issues/32074. So because of this I added an instruction in `main.js` to add the `--no-sandbox` flag to the electron app and this fixes the issue.

---

When submitting a pull request, make sure you do the following:

- [x] submit the PR to the `dev` branch on the main repo, **not** the `master` branch
- [x] in the body, reference the issue that it closes by number in the format `Closes #000`  
       *Not applicable*
